### PR TITLE
some changes to make_examples function

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,8 @@
 		"ghcr.io/dhoeric/features/act:1": {},
 		"ghcr.io/hspaans/devcontainer-features/pytest:1": {},
 		"ghcr.io/meaningful-ooo/devcontainer-features/fish:1": {},
-		"ghcr.io/stuartleeks/dev-container-features/shell-history:0": {}
+		"ghcr.io/stuartleeks/dev-container-features/shell-history:0": {},
+		"ghcr.io/devcontainers/features/github-cli:1": {}
 	},
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.

--- a/src/heavylight/make_examples.py
+++ b/src/heavylight/make_examples.py
@@ -9,25 +9,17 @@ heavylight.make_example('example', 'path/to/folder')
 or using a simple CLI
 
 '''
-import os
 import shutil
-import pathlib
+from pathlib import Path
+from typing import Union, Literal
 
 examples = ['template', 'protection']
+ExampleName = Literal['template', 'protection']
 
-def make_example(path: str|pathlib.Path, example_name:str):
-    if example_name in examples:
-        base_src_path = pathlib.Path(os.path.realpath(__file__))
-        # print(f"{base_src_path=}")
-        example_path = base_src_path.parent / 'examples' / example_name
-        # print(f"{example_path=}")
-        dest_path = pathlib.Path(path) / example_name
-        print(f'Creating {example_name} at {dest_path}')
-        shutil.copytree(src=example_path, dst=dest_path)
-        # TODO: print a nice view of the files and folders set up (like hatch new)
-
-    else:
+def make_example(download_to_path: Union[str, Path], example_name: ExampleName):
+    if not example_name in examples:
         raise ValueError(f'example {example_name} not in available examples {examples}')
-
-if __name__ == '__main__':
-    make_example('/Users/lewisfogden/Dev/pyscratch/temp', 'protection')
+    example_path = Path(__file__).resolve().parent / 'examples' / example_name
+    dest_path = Path(download_to_path).resolve() / example_name
+    print(f'Creating {example_name} at {dest_path}')
+    shutil.copytree(src=example_path, dst=dest_path)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,0 +1,14 @@
+from heavylight import make_example
+from pathlib import Path
+import shutil
+import pytest
+
+def test_make_example_bad():
+    with pytest.raises(ValueError):
+        make_example('temp', 'bad')
+
+def test_make_example_protection():
+    make_example('temp', 'protection')
+    assert (Path('temp') / 'protection').exists()
+    shutil.rmtree('temp/protection')
+


### PR DESCRIPTION
test the make_examples function

denest the code, it is common to throw errors early in the function and then have no indentation in the rest of the function body

Avoid using both os and pathlib when pathlib alone should work

update type annotations in signature to be compatible for 3.8 with download_to_path, use union literal for autocomplete in example_name.