### PR TITLE
destroy kwargs + Before/AfterRun

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ Model:
 
 - projection controller
 - class to subclass with your proprietary models
-- `BeforeRun` and `AfterRun` methods
 - get all values as a list with `values` attribute
 - get the sum of all values with `sum()` method
 

--- a/src/heavylight/heavylight.py
+++ b/src/heavylight/heavylight.py
@@ -26,24 +26,16 @@ class _Cache:
 
     def __repr__(self):
         return f"<Cache Function: {self.func.__name__} Params: {self.param_names} Size: {len(self._store)}>"
-    
-    def sum(self):
-        """return the sum of all values in the Cache Function"""
-        return sum(self._store.values())
-    
-    @property
-    def keys(self):
-        return list(self._store.keys())
 
     @property
-    def values(self):
-        return list(self._store.values())
+    def cache(self):
+        return self._store
     
     @property
     def df(self):
         """return the cache as a pandas dataframe"""
-        df = pd.DataFrame(data=self.keys, columns=self.param_names)
-        df[self.__name__] = self.values
+        df = pd.DataFrame(data=self.cache.keys(), columns=self.param_names)
+        df[self.__name__] = self.cache.values()
         # df = df.set_index(list(self.param_names))  # TODO: decide if keys should be indexes or not.
         return df
 
@@ -146,7 +138,7 @@ class Model:
         df = pd.DataFrame()
         for func in self._funcs:
             if self._funcs[func].has_one_param and self._funcs[func].param_names[0] == param:
-                df[func] = pd.Series(self._funcs[func].values)
+                df[func] = pd.Series(self._funcs[func].cache.values())
 
         # if t is in the dataframe, move it to first position
         if "t" in df.columns:

--- a/tests/test_heavylight.py
+++ b/tests/test_heavylight.py
@@ -30,7 +30,7 @@ class SimpleModel(Model):
 
 def test_heavylight():
     model = SimpleModel(do_run = True, proj_len = 10)
-    assert model.pv_cashflow.sum() > 0
+    assert sum(model.pv_cashflow.cache.values()) > 0
 
 class UnitModel(Model):
     def t(self, t):
@@ -50,14 +50,14 @@ def test_no_kwargs(): # we do not support keyword arguments because multiple pos
 def test_UnitModel():
     proj_len = 10
     model = UnitModel(proj_len = proj_len)
-    assert model.func_t.sum() == sum(100 * t for t in range(proj_len))
-    assert model.func_a.values == []
-    assert model.t.values == list(range(proj_len))
+    assert sum(model.func_t.cache.values()) == sum(100 * t for t in range(proj_len))
+    assert list(model.func_a.cache.values()) == []
+    assert list(model.t.cache.values()) == list(range(proj_len))
     model.func_a(5)
     model.func_a(10)
     model.func_a(7)
-    assert model.func_a.values == [500, 1000, 700]  # values are ordered by insertion.
-    assert [k[0] for k in model.t.keys] == model.t.values  # keys are stored as tuples, need to grab the first one.
+    assert list(model.func_a.cache.values()) == [500, 1000, 700]  # values are ordered by insertion.
+    assert [k[0] for k in model.t.cache.keys()] == list(model.t.cache.values())  # keys are stored as tuples, need to grab the first one.
 
 class DataInput(Model):
     b = 4
@@ -90,7 +90,7 @@ class RecursiveModel(Model):
         
 def test_recursive():
     model = RecursiveModel(proj_len = 7, init_delta = 3)  # note overriding init_delta, this will warn
-    assert model.time_left.values == [14, 11, 8, 5, 2, 0, 0]
+    assert list(model.time_left.cache.values()) == [14, 11, 8, 5, 2, 0, 0]
 
 class MultipleParamModel(Model):
     def t(self, t):

--- a/tests/test_heavylight.py
+++ b/tests/test_heavylight.py
@@ -1,4 +1,5 @@
 from heavylight import Model
+import pytest
 
 class SimpleModel(Model):
     def t(self, t):
@@ -40,6 +41,11 @@ class UnitModel(Model):
     
     def func_a(self, a):
         return 100 * a
+
+def test_no_kwargs(): # we do not support keyword arguments because multiple possible hashes for same function call
+    sm = UnitModel()
+    with pytest.raises(ValueError):
+        sm.t(t=5)
 
 def test_UnitModel():
     proj_len = 10


### PR DESCRIPTION
This PR makes it explicit that kwargs are banned for `Model`.

Also destroys beforerun and afterrun